### PR TITLE
Fix role creation logic in add_roles

### DIFF
--- a/wp-content/mu-plugins/rise/includes/class-rise-users.php
+++ b/wp-content/mu-plugins/rise/includes/class-rise-users.php
@@ -16,53 +16,54 @@ class Rise_Users {
 	 *
 	 * @return void
 	 */
-	public function add_roles() {
-		$role = get_role( 'crew-member' );
+       public function add_roles() {
+               $caps = [
+                       'read'                            => true,
+                       'list_users'                      => true,
+                       'unfiltered_upload'               => true,
+                       'upload_files'                    => true,
+                       'edit_files'                      => true,
+                       'read_credits'                    => true,
+                       'publish_credits'                 => true,
+                       'edit_credits'                    => true,
+                       'edit_published_credits'          => true,
+                       'delete_published_credits'        => true,
+                       'read_saved_searches'             => true,
+                       'publish_saved_searches'          => true,
+                       'edit_saved_searches'             => true,
+                       'edit_published_saved_searches'   => true,
+                       'delete_published_saved_searches' => true,
+               ];
 
-		/**
-		 * Credits
-		 */
-		$role->add_cap( 'read_credits' );
-		$role->add_cap( 'publish_credits' );
-		$role->add_cap( 'edit_credits' );
-		$role->add_cap( 'edit_published_credits' );
-		$role->add_cap( 'delete_credits' );
-		$role->add_cap( 'delete_published_credits' );
+               $role = get_role( 'crew-member' );
 
-		/**
-		 * Saved Searches
-		 */
-		$role->add_cap( 'read_saved_searches' );
-		$role->add_cap( 'publish_saved_searches' );
-		$role->add_cap( 'edit_saved_searches' );
-		$role->add_cap( 'edit_published_saved_searches' );
-		$role->add_cap( 'delete_saved_searches' );
-		$role->add_cap( 'delete_published_saved_searches' );
+               if ( null === $role ) {
+                       add_role( 'crew-member', 'Crew Member', $caps );
+                       $role = get_role( 'crew-member' );
+               }
 
-		$roles = [
-			'crew-member' => [
-				'read'                            => true,
-				'list_users'                      => true,
-				'unfiltered_upload'               => true,
-				'upload_files'                    => true,
-				'edit_files'                      => true,
-				'read_credits'                    => true,
-				'publish_credits'                 => true,
-				'edit_credits'                    => true,
-				'edit_published_credits'          => true,
-				'delete_published_credits'        => true,
-				'read_saved_searches'             => true,
-				'publish_saved_searches'          => true,
-				'edit_saved_searches'             => true,
-				'edit_published_saved_searches'   => true,
-				'delete_published_saved_searches' => true,
-			],
-		];
+               if ( $role ) {
+                       /**
+                        * Credits
+                        */
+                       $role->add_cap( 'read_credits' );
+                       $role->add_cap( 'publish_credits' );
+                       $role->add_cap( 'edit_credits' );
+                       $role->add_cap( 'edit_published_credits' );
+                       $role->add_cap( 'delete_credits' );
+                       $role->add_cap( 'delete_published_credits' );
 
-		foreach ( $roles as $role => $caps ) {
-			add_role( $role, $caps );
-		}
-	}
+                       /**
+                        * Saved Searches
+                        */
+                       $role->add_cap( 'read_saved_searches' );
+                       $role->add_cap( 'publish_saved_searches' );
+                       $role->add_cap( 'edit_saved_searches' );
+                       $role->add_cap( 'edit_published_saved_searches' );
+                       $role->add_cap( 'delete_saved_searches' );
+                       $role->add_cap( 'delete_published_saved_searches' );
+               }
+       }
 
 	/**
 	 * Blocks access to the Dashboard for users with the 'crew-member' role.


### PR DESCRIPTION
## Summary
- fix `add_roles` to create 'crew-member' role when it does not exist
- add capabilities only when the role object is valid

## Testing
- `php -l wp-content/mu-plugins/rise/includes/class-rise-users.php`

------
https://chatgpt.com/codex/tasks/task_e_684707ed9254832987ccb8be4a3af84f