### PR TITLE
Fix typo in personal identity description

### DIFF
--- a/wp-content/mu-plugins/rise/includes/class-rise-graphql-queries.php
+++ b/wp-content/mu-plugins/rise/includes/class-rise-graphql-queries.php
@@ -591,7 +591,7 @@ class Rise_GraphQL_Queries {
 			'personalIdentities',
 			[
 				'type'        => ['list_of' => 'Personal_Identity'],
-				'description' => __( 'The user\'s seelcted personal identity terms.', 'rise' ),
+                                'description' => __( 'The user\'s selected personal identity terms.', 'rise' ),
 				'resolve'     => function ( $user ) {
 					return self::prepare_taxonomy_terms( $user->fields['userId'], 'personal_identity' );
 				},


### PR DESCRIPTION
## Summary
- fix a typo in the `personalIdentities` GraphQL field description

## Testing
- `php -l wp-content/mu-plugins/rise/includes/class-rise-graphql-queries.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684708791b508329a997b2e772d05163