### PR TITLE
Update get_job_skills documentation

### DIFF
--- a/wp-content/mu-plugins/rise/includes/class-rise-graphql-queries.php
+++ b/wp-content/mu-plugins/rise/includes/class-rise-graphql-queries.php
@@ -89,13 +89,15 @@ class Rise_GraphQL_Queries {
 		return $prepared_terms;
 	}
 
-	/**
-	 * Get jobs from departments.
-	 *
-	 * @param  array $departments
-	 * @return array An array of job IDs.
-	 */
-	private static function get_job_skills( $jobs ) {
+       /**
+        * Retrieve skills for specified jobs.
+        *
+        * Returns skills related to the provided job IDs.
+        *
+        * @param array $jobs Job IDs to look up.
+        * @return array An array of skill terms.
+        */
+       private static function get_job_skills( $jobs ) {
 		$selected_skills = [];
 		foreach ( $jobs as $job ) {
 			$pod       = pods( 'position', $job );


### PR DESCRIPTION
## Summary
- clarify the purpose of `get_job_skills` and update parameter name

## Testing
- `php -l wp-content/mu-plugins/rise/includes/class-rise-graphql-queries.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847087ec2848329869dbaad5e83504b