### PR TITLE
Add utility helper unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ Thumbs.db
 !readme.txt
 !CHANGELOG.md
 !composer.json
+!phpunit.xml
+!tests/
+!tests/**
 
 # Plugins and Themes
 !wp-content/themes/rise-theme

--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ Current tooling:
 - theme.json
   - Set up font size defaults to match frontend's size chart.
   - TODO: clean up theme.json, removing all unnecessary properties and attributes.
+
+## Running Tests
+
+Install PHPUnit via your package manager and run:
+
+```bash
+phpunit
+```
+from the repository root.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Rise Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,0 +1,19 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class UtilsTest extends TestCase
+{
+    public function testCamelToSnake()
+    {
+        $this->assertSame('camel_to_snake', camel_to_snake('camelToSnake'));
+        $this->assertSame('camel_to_snake_case', camel_to_snake('camelToSnakeCase'));
+        $this->assertSame('hello_world_123', camel_to_snake('helloWorld123'));
+    }
+
+    public function testSnakeToCamel()
+    {
+        $this->assertSame('camelToSnake', snake_to_camel('camel_to_snake'));
+        $this->assertSame('camelToSnakeCase', snake_to_camel('camel_to_snake_case'));
+        $this->assertSame('helloWorld123', snake_to_camel('hello_world_123'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+// Load the utility functions to test.
+require_once __DIR__ . '/../wp-content/mu-plugins/rise/includes/utils.php';

--- a/wp-content/mu-plugins/rise/includes/utils.php
+++ b/wp-content/mu-plugins/rise/includes/utils.php
@@ -63,10 +63,12 @@ function camel_to_snake( $string ) {
  * @return string The converted string.
  */
 function snake_to_camel( $string ) {
-	$string = strtolower( $string );
-	$string = preg_replace( '/_([a-z0-9])/e', 'strtoupper("$1")', $string );
-	$string = lcfirst( $string );
-	return $string;
+        $string = strtolower( $string );
+        $string = preg_replace_callback( '/_([a-z0-9])/', function( $matches ) {
+                return strtoupper( $matches[1] );
+        }, $string );
+        $string = lcfirst( $string );
+        return $string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add PHPUnit test runner configuration
- add tests for camel_to_snake() and snake_to_camel()
- fix snake_to_camel() for PHP 8 compatibility
- document running the test suite

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6847088c6ab48329a801f5bb759e409e